### PR TITLE
James/dat 1003

### DIFF
--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -146,7 +146,7 @@
 {% block extrafoot %}
 {% if data['features'] %}
     <script>
-    var map = L.map('items-map').setView([{{ 45 }}, {{ -75 }}], 5);
+    var map = L.map('items-map').setView([{{ -25 }}, {{ 135 }}], 3.25);
     map.addLayer(new L.TileLayer(
         '{{ config['server']['map']['url'] }}', {
             maxZoom: 18,


### PR DESCRIPTION
# Overview

The issue is that the default map layer of PygeoAPI is set to Canada (Montreal). Users will see this map when there is not valid coordinate data for PygeoAPI to use. The default map has been adjusted to the map of Australia. 

# Related issue / discussion

https://gajira.atlassian.net/browse/DAT-1003

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
