### PR TITLE
Remove "disableClusteringAtZoom" parameter to fix issues with overlapping geometric points

### DIFF
--- a/pygeoapi/templates/collections/items/index.html
+++ b/pygeoapi/templates/collections/items/index.html
@@ -173,7 +173,6 @@
     });
     {% if data['features'][0]['geometry']['type'] == 'Point' %}
     var markers = L.markerClusterGroup({
-        disableClusteringAtZoom: 9,
         chunkedLoading: true,
         chunkInterval: 500,
     });


### PR DESCRIPTION
# Overview

This parameter set by the PygeoAPI developers is causing issues for our data when we have samples/sites/etc with duplicate coordinates. Only 1 marker is shown when the clusters are disabled. 

Removing this parameter will allow us to see all clusters for overlapping sites/samples/etc. 

# Related Issue / discussion

https://gajira.atlassian.net/browse/DAT-1053

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
