### PR TITLE
Customisation of Collection Schemas to display additional metadata

### DIFF
--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -274,14 +274,29 @@ class DatabaseConnection:
         LOGGER.debug("Table: " + table)
 
         if self.context == "query":
-            columns = dict(self._get_table_columns(schema, table))
+            #GA Customisation - Multiple columns are returned as we are populating multiple columns in the schema
+
+            type_columns = dict(self._get_table_columns(schema, table)[0])
+            comment_columns = dict(self._get_table_columns(schema, table)[1])
+            mandatory_columns = dict(self._get_table_columns(schema, table)[2])
+
+            #End GA Customisation
 
             # Populate dictionary for columns with column type
             # NOTE: we want all columns available here because they are
             #       used for filtering in the where clause, not only
             #       the ones that are returned to the client.
-            for k, v in columns.items():
-                self.fields[k.lower()] = {"type": v}
+
+            #GA Custimisation - Fields now grabs all the columns produced from the altered get_table_columns function
+            for k, v in type_columns.items():
+                comment_value = comment_columns[k]
+                mandatory_value = mandatory_columns[k]
+                self.fields[k.lower()] = {
+                                    "type": v,
+                                    "comments": comment_value,
+                                    "mandatory": mandatory_value
+                                    }
+            #End GA Customisation
 
             filtered_columns = set(self.fields)
             if self.properties:
@@ -371,20 +386,49 @@ class DatabaseConnection:
             schema = result[0]
             table = result[1]
 
+        #GA Customisation - Add multiple queries for each column required
+
         # Get table column names and types, excluding geometry
-        query_cols = """
+        query_type_cols = """
                      SELECT column_name, data_type
-                       FROM all_tab_columns
+                       FROM PUB_DATA.PIDUSER_VIEW_SCHEMA_METADATA
                       WHERE table_name = UPPER(:table_name)
                         AND owner = UPPER(:owner)
                         AND data_type != 'SDO_GEOMETRY'
                      """
+
+        # Get table column names and comments, excluding geometry
+
+        query_comment_cols = """
+                     SELECT column_name, column_comment
+                       FROM PUB_DATA.PIDUSER_VIEW_SCHEMA_METADATA
+                      WHERE table_name = UPPER(:table_name)
+                        AND owner = UPPER(:owner)
+                        AND data_type != 'SDO_GEOMETRY'
+                     """
+
+        # Get table column names and mandatory property, excluding geometry
+
+        query_mandatory_cols = """
+                     SELECT column_name, mandatory
+                       FROM PUB_DATA.PIDUSER_VIEW_SCHEMA_METADATA 
+                      WHERE table_name = UPPER(:table_name)
+                        AND owner = UPPER(:owner)
+                        AND data_type != 'SDO_GEOMETRY'
+                     """ 
         with self.conn.cursor() as cur:
-            cur.execute(query_cols, {"table_name": table, "owner": schema})
-            result = cur.fetchall()
+            #type query
+            cur.execute(query_type_cols, {"table_name": table, "owner": schema})
+            type_result = cur.fetchall()
+            #comment query
+            cur.execute(query_comment_cols, {"table_name": table, "owner": schema})
+            comment_result = cur.fetchall()
+            #mandatory query
+            cur.execute(query_mandatory_cols, {"table_name": table, "owner": schema})
+            mandatory_result = cur.fetchall()
 
-        return result
-
+        return type_result, comment_result, mandatory_result
+        #End GA Customisation
 
 class OracleProvider(BaseProvider):
     def __init__(self, provider_def):

--- a/pygeoapi/templates/collections/schema.html
+++ b/pygeoapi/templates/collections/schema.html
@@ -17,14 +17,12 @@
       <h3>{% trans %}Schema{% endtrans %}</h3>
       <table class="table table-striped table-bordered">
         <th>Name</th>
-        <th>Title</th>
-        <th>Type</th>
-        <th>Units</th>
-        <th>Values</th>
+        <th>Data Type</th>
+        <th>Comments</th>
+        <th>Mandatory</th>
       {% for qname, qinfo in data['properties'].items() %}
         <tr>
           <td>{{ qname }}</td>
-          <td>{{ qinfo['title'] }}</td>
           {% if qname == 'geometry' %}
           <td><a href="{{ qinfo['$ref'] }}">{{ qname }} </a></td>
           {% else %}
@@ -34,14 +32,8 @@
           {% endif %}
           </td>
           {% endif %}
-          <td>{{ qinfo['x-ogc-unit'] }}</td>
-          <td>
-            <ul>
-            {% for value in qinfo['enum'] %}
-              <li><i>{{ value }}</i></li>
-            {% endfor %}
-            </ul>
-          </td>
+          <td>{{ qinfo['comments'] }}</td>
+          <td style="text-align: center">{{ qinfo['mandatory'] }}</td>
         </tr>
       {% endfor %}
       </table>


### PR DESCRIPTION
# Overview

The default collection schema feature implemented in PygeoAPI 0.20.0 did not have any information aside from the column name and data type, this customisation allows us to get some additional information about the schema.

# Related Issue / discussion

https://gajira.atlassian.net/browse/DAT-1052

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
