### PR TITLE
Correction to Oracle.py _get_previous() SQL logic

### DIFF
--- a/pygeoapi/provider/oracle.py
+++ b/pygeoapi/provider/oracle.py
@@ -938,11 +938,14 @@ class OracleProvider(BaseProvider):
 
         :returns: feature id
         """
-        sql = f"SELECT {self.id_field} AS id \
+        sql = f"SELECT * \
+                FROM ( \
+                SELECT {self.id_field} AS id \
                   FROM {self.table} \
-                 WHERE ROWNUM = 1 \
-                   AND {self.id_field} < :{self.id_field} \
-                 ORDER BY {self.id_field} DESC"
+                  WHERE {self.id_field} < :{self.id_field} \
+                  ORDER BY {self.id_field} DESC \
+                ) \
+                WHERE ROWNUM = 1"
 
         bind_variables = {self.id_field: identifier}
 


### PR DESCRIPTION
# Overview

On the item level of collections, the previous link was not behaving as expected and not sending the user to the previous record in the collection. This PR corrects the logic of the SQL used for the previous record so that it actually gets the previous record as expected.

# Related Issue / discussion

https://gajira.atlassian.net/browse/DAT-1039

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
