### PR TITLE
Pin Trivy to safe version

### DIFF
--- a/.github/workflows/vulnerabilities.yml
+++ b/.github/workflows/vulnerabilities.yml
@@ -16,7 +16,7 @@ on:
 jobs:
 
   vulnerabilities:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: .
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout pygeoapi
       uses: actions/checkout@master
     - name: Scan vulnerabilities with trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: fs
         exit-code: 1
@@ -36,7 +36,7 @@ jobs:
       run: |
         docker buildx build -t ${{ github.repository }}:${{ github.sha }} --platform linux/amd64 --no-cache -f Dockerfile .
     - name: Scan locally built Docker image for vulnerabilities with trivy
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       env:
         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1


### PR DESCRIPTION
# Overview

In the wake of the recent trivy vulnerability, this change reflects the actions taken by the PygeoAPI developers. This change is in line with ensuring there is minimal code drift as this will match the code change found in the PygeoAPI repo when we upgrade in the future.

See the following link for the change made on the PygeoAPI repo: https://github.com/geopython/pygeoapi/pull/2293/changes

# Related Issue / discussion

https://gajira.atlassian.net/browse/DAT-1327

<!--

Is there an existing Issue that this PR addresses?  Does this PR need a new Issue?

Non-trivial PRs are best put forth initially as an Issue so that there can be
discussion and consensus before a PR is put forth.

-->

# Additional information

# Dependency policy (RFC2)

- [ ] I have ensured that this PR meets [RFC2](https://pygeoapi.io/development/rfc/2) requirements

# Updates to public demo

- [ ] I have ensured that breaking changes to the [pygeoapi master demo server](https://github.com/geopython/demo.pygeoapi.io) have been addressed
  - [ ] https://github.com/geopython/demo.pygeoapi.io/blob/master/services/pygeoapi_master/local.config.yml

# Contributions and licensing

(as per https://github.com/geopython/pygeoapi/blob/master/CONTRIBUTING.md#contributions-and-licensing)

- [ ] I'd like to contribute [feature X|bugfix Y|docs|something else] to pygeoapi. I confirm that my contributions to pygeoapi will be compatible with the pygeoapi license guidelines at the time of contribution
- [ ] I have already previously agreed to the pygeoapi Contributions and Licensing Guidelines
